### PR TITLE
Revamp TableEditor UI for structured AnmChr editing

### DIFF
--- a/MarvelEditTool/TableEditor.Designer.cs
+++ b/MarvelEditTool/TableEditor.Designer.cs
@@ -41,6 +41,25 @@
             this.exportButton = new System.Windows.Forms.Button();
             this.extendButton = new System.Windows.Forms.Button();
             this.sizeLabel = new System.Windows.Forms.Label();
+            this.entryTabControl = new System.Windows.Forms.TabControl();
+            this.structureTabPage = new System.Windows.Forms.TabPage();
+            this.structureUnavailableLabel = new System.Windows.Forms.Label();
+            this.structureLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.subEntryLabel = new System.Windows.Forms.Label();
+            this.commandLabel = new System.Windows.Forms.Label();
+            this.subEntryLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.subEntryListBox = new System.Windows.Forms.ListBox();
+            this.subEntryButtonPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.subEntryUpButton = new System.Windows.Forms.Button();
+            this.subEntryDownButton = new System.Windows.Forms.Button();
+            this.commandLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.commandListBox = new System.Windows.Forms.ListBox();
+            this.commandButtonPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.commandMoveUpButton = new System.Windows.Forms.Button();
+            this.commandMoveDownButton = new System.Windows.Forms.Button();
+            this.commandDetailLabel = new System.Windows.Forms.Label();
+            this.commandDetailTextBox = new System.Windows.Forms.TextBox();
+            this.rawDataTabPage = new System.Windows.Forms.TabPage();
             this.dataTextBox = new System.Windows.Forms.TextBox();
             this.analyzeButton = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -55,6 +74,14 @@
             this.splitContainer3.Panel1.SuspendLayout();
             this.splitContainer3.Panel2.SuspendLayout();
             this.splitContainer3.SuspendLayout();
+            this.entryTabControl.SuspendLayout();
+            this.structureTabPage.SuspendLayout();
+            this.structureLayoutPanel.SuspendLayout();
+            this.subEntryLayoutPanel.SuspendLayout();
+            this.subEntryButtonPanel.SuspendLayout();
+            this.commandLayoutPanel.SuspendLayout();
+            this.commandButtonPanel.SuspendLayout();
+            this.rawDataTabPage.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -156,8 +183,8 @@
             this.splitContainer3.Panel1.Controls.Add(this.tableLayoutPanel1);
             // 
             // splitContainer3.Panel2
-            // 
-            this.splitContainer3.Panel2.Controls.Add(this.dataTextBox);
+            //
+            this.splitContainer3.Panel2.Controls.Add(this.entryTabControl);
             this.splitContainer3.Size = new System.Drawing.Size(415, 526);
             this.splitContainer3.SplitterDistance = 179;
             this.splitContainer3.TabIndex = 5;
@@ -252,17 +279,257 @@
             this.sizeLabel.Size = new System.Drawing.Size(44, 17);
             this.sizeLabel.TabIndex = 4;
             this.sizeLabel.Text = "ready";
-            // 
+            //
+            // entryTabControl
+            //
+            this.entryTabControl.Controls.Add(this.structureTabPage);
+            this.entryTabControl.Controls.Add(this.rawDataTabPage);
+            this.entryTabControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.entryTabControl.Location = new System.Drawing.Point(0, 0);
+            this.entryTabControl.Name = "entryTabControl";
+            this.entryTabControl.SelectedIndex = 0;
+            this.entryTabControl.Size = new System.Drawing.Size(415, 343);
+            this.entryTabControl.TabIndex = 0;
+            //
+            // structureTabPage
+            //
+            this.structureTabPage.Controls.Add(this.structureLayoutPanel);
+            this.structureTabPage.Controls.Add(this.structureUnavailableLabel);
+            this.structureTabPage.Location = new System.Drawing.Point(4, 25);
+            this.structureTabPage.Name = "structureTabPage";
+            this.structureTabPage.Padding = new System.Windows.Forms.Padding(3);
+            this.structureTabPage.Size = new System.Drawing.Size(407, 314);
+            this.structureTabPage.TabIndex = 0;
+            this.structureTabPage.Text = "Structure";
+            this.structureTabPage.UseVisualStyleBackColor = true;
+            //
+            // structureUnavailableLabel
+            //
+            this.structureUnavailableLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.structureUnavailableLabel.Location = new System.Drawing.Point(3, 3);
+            this.structureUnavailableLabel.Name = "structureUnavailableLabel";
+            this.structureUnavailableLabel.Size = new System.Drawing.Size(401, 308);
+            this.structureUnavailableLabel.TabIndex = 1;
+            this.structureUnavailableLabel.Text = "Structured view is only available for AnmChr entries.";
+            this.structureUnavailableLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.structureUnavailableLabel.Visible = false;
+            //
+            // structureLayoutPanel
+            //
+            this.structureLayoutPanel.ColumnCount = 2;
+            this.structureLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 40F));
+            this.structureLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 60F));
+            this.structureLayoutPanel.Controls.Add(this.subEntryLabel, 0, 0);
+            this.structureLayoutPanel.Controls.Add(this.commandLabel, 1, 0);
+            this.structureLayoutPanel.Controls.Add(this.subEntryLayoutPanel, 0, 1);
+            this.structureLayoutPanel.Controls.Add(this.commandLayoutPanel, 1, 1);
+            this.structureLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.structureLayoutPanel.Location = new System.Drawing.Point(3, 3);
+            this.structureLayoutPanel.Name = "structureLayoutPanel";
+            this.structureLayoutPanel.RowCount = 2;
+            this.structureLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.structureLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.structureLayoutPanel.Size = new System.Drawing.Size(401, 308);
+            this.structureLayoutPanel.TabIndex = 0;
+            //
+            // subEntryLabel
+            //
+            this.subEntryLabel.AutoSize = true;
+            this.subEntryLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.subEntryLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.subEntryLabel.Location = new System.Drawing.Point(3, 0);
+            this.subEntryLabel.Name = "subEntryLabel";
+            this.subEntryLabel.Size = new System.Drawing.Size(154, 18);
+            this.subEntryLabel.TabIndex = 0;
+            this.subEntryLabel.Text = "Command blocks";
+            this.subEntryLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            //
+            // commandLabel
+            //
+            this.commandLabel.AutoSize = true;
+            this.commandLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.commandLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.commandLabel.Location = new System.Drawing.Point(163, 0);
+            this.commandLabel.Name = "commandLabel";
+            this.commandLabel.Size = new System.Drawing.Size(235, 18);
+            this.commandLabel.TabIndex = 1;
+            this.commandLabel.Text = "Commands";
+            this.commandLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            //
+            // subEntryLayoutPanel
+            //
+            this.subEntryLayoutPanel.ColumnCount = 1;
+            this.subEntryLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.subEntryLayoutPanel.Controls.Add(this.subEntryListBox, 0, 0);
+            this.subEntryLayoutPanel.Controls.Add(this.subEntryButtonPanel, 0, 1);
+            this.subEntryLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.subEntryLayoutPanel.Location = new System.Drawing.Point(3, 21);
+            this.subEntryLayoutPanel.Name = "subEntryLayoutPanel";
+            this.subEntryLayoutPanel.RowCount = 2;
+            this.subEntryLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.subEntryLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.subEntryLayoutPanel.Size = new System.Drawing.Size(154, 284);
+            this.subEntryLayoutPanel.TabIndex = 2;
+            //
+            // subEntryListBox
+            //
+            this.subEntryListBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.subEntryListBox.Enabled = false;
+            this.subEntryListBox.FormattingEnabled = true;
+            this.subEntryListBox.IntegralHeight = false;
+            this.subEntryListBox.ItemHeight = 16;
+            this.subEntryListBox.Location = new System.Drawing.Point(3, 3);
+            this.subEntryListBox.Name = "subEntryListBox";
+            this.subEntryListBox.Size = new System.Drawing.Size(148, 246);
+            this.subEntryListBox.TabIndex = 0;
+            this.subEntryListBox.SelectedIndexChanged += new System.EventHandler(this.subEntryListBox_SelectedIndexChanged);
+            //
+            // subEntryButtonPanel
+            //
+            this.subEntryButtonPanel.AutoSize = true;
+            this.subEntryButtonPanel.Controls.Add(this.subEntryUpButton);
+            this.subEntryButtonPanel.Controls.Add(this.subEntryDownButton);
+            this.subEntryButtonPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.subEntryButtonPanel.FlowDirection = System.Windows.Forms.FlowDirection.LeftToRight;
+            this.subEntryButtonPanel.Location = new System.Drawing.Point(3, 255);
+            this.subEntryButtonPanel.Name = "subEntryButtonPanel";
+            this.subEntryButtonPanel.Size = new System.Drawing.Size(148, 26);
+            this.subEntryButtonPanel.TabIndex = 1;
+            //
+            // subEntryUpButton
+            //
+            this.subEntryUpButton.AutoSize = true;
+            this.subEntryUpButton.Enabled = false;
+            this.subEntryUpButton.Location = new System.Drawing.Point(3, 3);
+            this.subEntryUpButton.Name = "subEntryUpButton";
+            this.subEntryUpButton.Size = new System.Drawing.Size(70, 23);
+            this.subEntryUpButton.TabIndex = 0;
+            this.subEntryUpButton.Text = "Move Up";
+            this.subEntryUpButton.UseVisualStyleBackColor = true;
+            this.subEntryUpButton.Click += new System.EventHandler(this.subEntryUpButton_Click);
+            //
+            // subEntryDownButton
+            //
+            this.subEntryDownButton.AutoSize = true;
+            this.subEntryDownButton.Enabled = false;
+            this.subEntryDownButton.Location = new System.Drawing.Point(79, 3);
+            this.subEntryDownButton.Name = "subEntryDownButton";
+            this.subEntryDownButton.Size = new System.Drawing.Size(66, 23);
+            this.subEntryDownButton.TabIndex = 1;
+            this.subEntryDownButton.Text = "Move Down";
+            this.subEntryDownButton.UseVisualStyleBackColor = true;
+            this.subEntryDownButton.Click += new System.EventHandler(this.subEntryDownButton_Click);
+            //
+            // commandLayoutPanel
+            //
+            this.commandLayoutPanel.ColumnCount = 1;
+            this.commandLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.commandLayoutPanel.Controls.Add(this.commandListBox, 0, 0);
+            this.commandLayoutPanel.Controls.Add(this.commandButtonPanel, 0, 1);
+            this.commandLayoutPanel.Controls.Add(this.commandDetailLabel, 0, 2);
+            this.commandLayoutPanel.Controls.Add(this.commandDetailTextBox, 0, 3);
+            this.commandLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.commandLayoutPanel.Location = new System.Drawing.Point(163, 21);
+            this.commandLayoutPanel.Name = "commandLayoutPanel";
+            this.commandLayoutPanel.RowCount = 4;
+            this.commandLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 55F));
+            this.commandLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.commandLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.commandLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 45F));
+            this.commandLayoutPanel.Size = new System.Drawing.Size(235, 284);
+            this.commandLayoutPanel.TabIndex = 3;
+            //
+            // commandListBox
+            //
+            this.commandListBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.commandListBox.Enabled = false;
+            this.commandListBox.FormattingEnabled = true;
+            this.commandListBox.IntegralHeight = false;
+            this.commandListBox.ItemHeight = 16;
+            this.commandListBox.Location = new System.Drawing.Point(3, 3);
+            this.commandListBox.Name = "commandListBox";
+            this.commandListBox.Size = new System.Drawing.Size(229, 138);
+            this.commandListBox.TabIndex = 0;
+            this.commandListBox.SelectedIndexChanged += new System.EventHandler(this.commandListBox_SelectedIndexChanged);
+            //
+            // commandButtonPanel
+            //
+            this.commandButtonPanel.AutoSize = true;
+            this.commandButtonPanel.Controls.Add(this.commandMoveUpButton);
+            this.commandButtonPanel.Controls.Add(this.commandMoveDownButton);
+            this.commandButtonPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.commandButtonPanel.FlowDirection = System.Windows.Forms.FlowDirection.LeftToRight;
+            this.commandButtonPanel.Location = new System.Drawing.Point(3, 147);
+            this.commandButtonPanel.Name = "commandButtonPanel";
+            this.commandButtonPanel.Size = new System.Drawing.Size(229, 29);
+            this.commandButtonPanel.TabIndex = 1;
+            //
+            // commandMoveUpButton
+            //
+            this.commandMoveUpButton.AutoSize = true;
+            this.commandMoveUpButton.Enabled = false;
+            this.commandMoveUpButton.Location = new System.Drawing.Point(3, 3);
+            this.commandMoveUpButton.Name = "commandMoveUpButton";
+            this.commandMoveUpButton.Size = new System.Drawing.Size(90, 23);
+            this.commandMoveUpButton.TabIndex = 0;
+            this.commandMoveUpButton.Text = "Move Up";
+            this.commandMoveUpButton.UseVisualStyleBackColor = true;
+            this.commandMoveUpButton.Click += new System.EventHandler(this.commandMoveUpButton_Click);
+            //
+            // commandMoveDownButton
+            //
+            this.commandMoveDownButton.AutoSize = true;
+            this.commandMoveDownButton.Enabled = false;
+            this.commandMoveDownButton.Location = new System.Drawing.Point(99, 3);
+            this.commandMoveDownButton.Name = "commandMoveDownButton";
+            this.commandMoveDownButton.Size = new System.Drawing.Size(96, 23);
+            this.commandMoveDownButton.TabIndex = 1;
+            this.commandMoveDownButton.Text = "Move Down";
+            this.commandMoveDownButton.UseVisualStyleBackColor = true;
+            this.commandMoveDownButton.Click += new System.EventHandler(this.commandMoveDownButton_Click);
+            //
+            // commandDetailLabel
+            //
+            this.commandDetailLabel.AutoSize = true;
+            this.commandDetailLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.commandDetailLabel.Location = new System.Drawing.Point(3, 179);
+            this.commandDetailLabel.Name = "commandDetailLabel";
+            this.commandDetailLabel.Size = new System.Drawing.Size(229, 17);
+            this.commandDetailLabel.TabIndex = 2;
+            this.commandDetailLabel.Text = "Command details";
+            //
+            // commandDetailTextBox
+            //
+            this.commandDetailTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.commandDetailTextBox.Location = new System.Drawing.Point(3, 199);
+            this.commandDetailTextBox.Multiline = true;
+            this.commandDetailTextBox.Name = "commandDetailTextBox";
+            this.commandDetailTextBox.ReadOnly = true;
+            this.commandDetailTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.commandDetailTextBox.Size = new System.Drawing.Size(229, 82);
+            this.commandDetailTextBox.TabIndex = 3;
+            //
+            // rawDataTabPage
+            //
+            this.rawDataTabPage.Controls.Add(this.dataTextBox);
+            this.rawDataTabPage.Location = new System.Drawing.Point(4, 25);
+            this.rawDataTabPage.Name = "rawDataTabPage";
+            this.rawDataTabPage.Padding = new System.Windows.Forms.Padding(3);
+            this.rawDataTabPage.Size = new System.Drawing.Size(407, 314);
+            this.rawDataTabPage.TabIndex = 1;
+            this.rawDataTabPage.Text = "Raw Data";
+            this.rawDataTabPage.UseVisualStyleBackColor = true;
+            //
             // dataTextBox
-            // 
+            //
             this.dataTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataTextBox.Font = new System.Drawing.Font("Consolas", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.dataTextBox.Location = new System.Drawing.Point(0, 0);
+            this.dataTextBox.Location = new System.Drawing.Point(3, 3);
             this.dataTextBox.Multiline = true;
             this.dataTextBox.Name = "dataTextBox";
             this.dataTextBox.ReadOnly = true;
             this.dataTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.dataTextBox.Size = new System.Drawing.Size(415, 343);
+            this.dataTextBox.Size = new System.Drawing.Size(401, 308);
             this.dataTextBox.TabIndex = 0;
             this.dataTextBox.WordWrap = false;
             // 
@@ -298,9 +565,22 @@
             this.splitContainer2.ResumeLayout(false);
             this.splitContainer3.Panel1.ResumeLayout(false);
             this.splitContainer3.Panel2.ResumeLayout(false);
-            this.splitContainer3.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer3)).EndInit();
             this.splitContainer3.ResumeLayout(false);
+            this.entryTabControl.ResumeLayout(false);
+            this.structureTabPage.ResumeLayout(false);
+            this.structureLayoutPanel.ResumeLayout(false);
+            this.structureLayoutPanel.PerformLayout();
+            this.subEntryLayoutPanel.ResumeLayout(false);
+            this.subEntryLayoutPanel.PerformLayout();
+            this.subEntryButtonPanel.ResumeLayout(false);
+            this.subEntryButtonPanel.PerformLayout();
+            this.commandLayoutPanel.ResumeLayout(false);
+            this.commandLayoutPanel.PerformLayout();
+            this.commandButtonPanel.ResumeLayout(false);
+            this.commandButtonPanel.PerformLayout();
+            this.rawDataTabPage.ResumeLayout(false);
+            this.rawDataTabPage.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
@@ -321,6 +601,25 @@
         private System.Windows.Forms.Button exportButton;
         private System.Windows.Forms.Label sizeLabel;
         private System.Windows.Forms.SplitContainer splitContainer3;
+        private System.Windows.Forms.TabControl entryTabControl;
+        private System.Windows.Forms.TabPage structureTabPage;
+        private System.Windows.Forms.TabPage rawDataTabPage;
+        private System.Windows.Forms.TableLayoutPanel structureLayoutPanel;
+        private System.Windows.Forms.TableLayoutPanel subEntryLayoutPanel;
+        private System.Windows.Forms.TableLayoutPanel commandLayoutPanel;
+        private System.Windows.Forms.ListBox subEntryListBox;
+        private System.Windows.Forms.ListBox commandListBox;
+        private System.Windows.Forms.FlowLayoutPanel subEntryButtonPanel;
+        private System.Windows.Forms.FlowLayoutPanel commandButtonPanel;
+        private System.Windows.Forms.Button subEntryUpButton;
+        private System.Windows.Forms.Button subEntryDownButton;
+        private System.Windows.Forms.Button commandMoveUpButton;
+        private System.Windows.Forms.Button commandMoveDownButton;
+        private System.Windows.Forms.Label subEntryLabel;
+        private System.Windows.Forms.Label commandLabel;
+        private System.Windows.Forms.Label commandDetailLabel;
+        private System.Windows.Forms.TextBox commandDetailTextBox;
+        private System.Windows.Forms.Label structureUnavailableLabel;
         private System.Windows.Forms.TextBox dataTextBox;
         private System.Windows.Forms.Label filenameLabel;
         private System.Windows.Forms.Button analyzeButton;


### PR DESCRIPTION
## Summary
- replace the raw hex-only layout with a tabbed interface that adds an AnmChr structure view alongside the existing raw data view
- surface AnmChr subentries and their commands through list-based navigation with move up/down actions and human-readable command details
- auto-detect AnmChr files and initialize command labels so the structured view stays in sync with the selected entry and any edits

## Testing
- not run (dotnet CLI is not available in the container)